### PR TITLE
Upload photo

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -126,6 +126,7 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-image-picker')
     compile project(':react-native-vector-icons')
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"

--- a/android/app/src/main/java/com/spark/MainApplication.java
+++ b/android/app/src/main/java/com/spark/MainApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.util.Log;
 
 import com.facebook.react.ReactApplication;
+import com.imagepicker.ImagePickerPackage;
 import com.oblador.vectoricons.VectorIconsPackage;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
@@ -26,6 +27,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
+            new ImagePickerPackage(),
             new VectorIconsPackage()
       );
     }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'Spark'
+include ':react-native-image-picker'
+project(':react-native-image-picker').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-image-picker/android')
 include ':react-native-vector-icons'
 project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-vector-icons/android')
 

--- a/ios/Spark.xcodeproj/project.pbxproj
+++ b/ios/Spark.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		E91BA5CA1C434C74B4C720BD /* Octicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 02C22524056F47B79F2F9471 /* Octicons.ttf */; };
 		8C5FA1A849A7407297ED641A /* SimpleLineIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0FE6F0E8CBDC4406A5589F78 /* SimpleLineIcons.ttf */; };
 		FA9BD33EDC2D48918858901B /* Zocial.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C2BE23B743B544C7834AEAFF /* Zocial.ttf */; };
+		EC0D572736CE47F1AAAAF046 /* libRNImagePicker.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BF49FDCD16E455883BA9976 /* libRNImagePicker.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -256,6 +257,8 @@
 		02C22524056F47B79F2F9471 /* Octicons.ttf */ = {isa = PBXFileReference; name = "Octicons.ttf"; path = "../node_modules/react-native-vector-icons/Fonts/Octicons.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
 		0FE6F0E8CBDC4406A5589F78 /* SimpleLineIcons.ttf */ = {isa = PBXFileReference; name = "SimpleLineIcons.ttf"; path = "../node_modules/react-native-vector-icons/Fonts/SimpleLineIcons.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
 		C2BE23B743B544C7834AEAFF /* Zocial.ttf */ = {isa = PBXFileReference; name = "Zocial.ttf"; path = "../node_modules/react-native-vector-icons/Fonts/Zocial.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
+		CC0B3FF2942E44169742C60A /* RNImagePicker.xcodeproj */ = {isa = PBXFileReference; name = "RNImagePicker.xcodeproj"; path = "../node_modules/react-native-image-picker/ios/RNImagePicker.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		6BF49FDCD16E455883BA9976 /* libRNImagePicker.a */ = {isa = PBXFileReference; name = "libRNImagePicker.a"; path = "libRNImagePicker.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -283,6 +286,7 @@
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
 				531E6B95B0F34B5BBDAEA215 /* libRNVectorIcons.a in Frameworks */,
+				EC0D572736CE47F1AAAAF046 /* libRNImagePicker.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -428,6 +432,7 @@
 				00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */,
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
 				C517876D8A1349678154CB10 /* RNVectorIcons.xcodeproj */,
+				CC0B3FF2942E44169742C60A /* RNImagePicker.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -881,6 +886,7 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 			};
 			name = Debug;
@@ -897,6 +903,7 @@
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Spark.app/Spark";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 			};

--- a/ios/Spark/Info.plist
+++ b/ios/Spark/Info.plist
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>Our custom Photo message</string>
+    <key>NSCameraUsageDescription</key>
+    <string>Our custom Camera message</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Our custom Mic message</string>
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>CFBundleExecutable</key>

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "immutability-helper": "^2.1.1",
     "react": "15.4.2",
     "react-native": "0.40.0",
+    "react-native-image-picker": "^0.25.1",
     "react-native-vector-icons": "^4.0.0",
     "redux": "^3.6.0",
     "redux-form": "^6.4.3",

--- a/src/js/components/upload-photo.js
+++ b/src/js/components/upload-photo.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { View, Text, Platform, PixelRatio, TouchableOpacity, Image } from 'react-native';
 import ImagePicker from 'react-native-image-picker';
+import Router from '../router';
 import Button from './common/Button';
 
 const styles = {
@@ -87,7 +88,7 @@ export default class UploadPhoto extends Component {
   }
 
   nextPage () {
-    this.props.navigator.push('navbar');
+    this.props.navigator.immediatelyResetStack([Router.getRoute('navbar')], 0);
   }
 
   render () {

--- a/src/js/components/upload-photo.js
+++ b/src/js/components/upload-photo.js
@@ -1,25 +1,118 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { Component } from 'react';
+import { View, Text, Platform, PixelRatio, TouchableOpacity, Image } from 'react-native';
+import ImagePicker from 'react-native-image-picker';
 import Button from './common/Button';
-import styles from '../../styles';
-import Router from '../router';
 
-export default function UploadPhoto ({ navigator }) {
+const styles = {
+  uploadContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  titleText: {
+    alignSelf: 'center',
+    marginTop: 50
+  },
+  avatarContainer: {
+    borderColor: '#9B9B9B',
+    borderWidth: 1 / PixelRatio.get(),
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  avatar: {
+    borderRadius: 75,
+    width: 150,
+    height: 150
+  },
+  skipButtonContainer: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0
+  },
+  skipButtonStyle: {
+    backgroundColor: '#578de5',
+    padding: 10,
+    flex: 1,
+    borderRadius: 5
+  },
+  skipButtonTextStyle: {
+    alignSelf: 'center',
+    color: '#fff'
+  }
+};
 
-  const nextPage = () => {
-    navigator.push(Router.getRoute('navbar'));
-  };
+export default class UploadPhoto extends Component {
 
-  return (
-    <View>
-      <Text style={{ marginTop: 50 }}>Upload Photo</Text>
-      <Button
-        onPress={ () => nextPage() }
-        buttonStyle={ styles.buttonStyle }
-        buttonTextStyle={ styles.buttonTextStyle }
-      >
-        Skip
-      </Button>
-    </View>
-  );
+  constructor (props) {
+    super(props);
+    this.state = { avatarSource: null };
+    this.nextPage = this.nextPage.bind(this);
+    this.selectPhotoTapped = this.selectPhotoTapped.bind(this);
+  }
+
+  selectPhotoTapped () {
+    const options = {
+      quality: 1.0,
+      maxWidth: 500,
+      maxheight: 500,
+      storageOptions: {
+        skipBackup: true
+      }
+    };
+
+    ImagePicker.showImagePicker(options, (response) => {
+      console.log('Response= ', response);
+
+      if (response.didCancel) {
+        console.log('User cancelled photo picker');
+      } else if (response.error) {
+        console.log('ImagePicker Error: ', response.error);
+      } else if (response.customButton) {
+        console.log('User tapped custom button ', response.customButton);
+      } else {
+        let source;
+        if (Platform.OS === 'android') {
+          source = { uri: response.uri };
+        } else {
+          console.log('uri', response.uri.replace('file://', ''));
+          source = { uri: response.uri.replace('file://', '') };
+        }
+
+        this.setState({
+          avatarSource: source
+        });
+      }
+    });
+  }
+
+  nextPage () {
+    this.props.navigator.push('navbar');
+  }
+
+  render () {
+    return (
+      <View style={{ flex: 1 }}>
+        <Text style={ styles.titleText }>Upload Photo</Text>
+        <View style={ styles.uploadContainer }>
+          <TouchableOpacity onPress={ this.selectPhotoTapped }>
+            <View style={ [styles.avatar, styles.avatarContainer, { marginBottom: 20 }] }>
+              { this.state.avatarSource === null ? <Text>Select a Photo</Text> :
+              <Image style={ styles.avatar } source={ this.state.avatarSource } />
+              }
+            </View>
+          </TouchableOpacity>
+        </View>
+        <View style={ styles.skipButtonContainer }>
+          <Button
+            buttonStyle={ styles.skipButtonStyle }
+            textStyle={ styles.skipButtonTextStyle }
+            onPress={ this.nextPage }
+          >
+            Skip
+          </Button>
+        </View>
+      </View>
+    );
+  }
 }


### PR DESCRIPTION
Related to #61 

Reminder:
UploadPhoto page is rendered after sign up. To skip sign up with backend you can replace in [L14](https://github.com/DRDD2016/native/blob/upload-photo/src/js/components/auth/index.js#L14) with route ```uploadPhoto``` instead of ```signup```. So on Intro page you just click on sign up and go straight to uploadPhoto for testing this PR.