### PR TITLE
Finalised

### DIFF
--- a/__tests__/unit/actions/event/update-rsvp.js
+++ b/__tests__/unit/actions/event/update-rsvp.js
@@ -1,0 +1,185 @@
+import * as actions from '../../../../src/js/actions/event/data';
+
+
+describe('GET_EVENT actions', () => {
+
+  describe('`getEventRequest` action creator', () => {
+
+    it('returns expected action', () => {
+
+      const expected = {
+        type: actions.GET_EVENT_REQUEST
+      };
+
+      const actual = actions.getEventRequest();
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('`getEventSuccess` action creator', () => {
+
+    it('returns expected action', () => {
+      const data = {};
+      const expected = {
+        type: actions.GET_EVENT_SUCCESS,
+        data
+      };
+
+      const actual = actions.getEventSuccess(data);
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('`getEventFailure` action creator', () => {
+
+    it('returns expected action', () => {
+
+      const error = new Error();
+      const expected = {
+        type: actions.GET_EVENT_FAILURE,
+        error
+      };
+
+      const actual = actions.getEventFailure(error);
+      expect(actual).toEqual(expected);
+    });
+  });
+});
+
+
+describe('SUBMIT_CODE_EVENT actions', () => {
+
+  describe('`submitCodeRequest` action creator', () => {
+
+    it('returns expected action', () => {
+
+      const expected = {
+        type: actions.SUBMIT_CODE_REQUEST
+      };
+
+      const actual = actions.submitCodeRequest();
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('`submitCodeSuccess` action creator', () => {
+
+    it('returns expected action', () => {
+      const data = {};
+      const expected = {
+        type: actions.SUBMIT_CODE_SUCCESS,
+        data
+      };
+
+      const actual = actions.submitCodeSuccess(data);
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('`submitCodeFailure` action creator', () => {
+
+    it('returns expected action', () => {
+
+      const error = new Error();
+      const expected = {
+        type: actions.SUBMIT_CODE_FAILURE,
+        error
+      };
+
+      const actual = actions.submitCodeFailure(error);
+      expect(actual).toEqual(expected);
+    });
+  });
+});
+
+
+describe('EDIT_EVENT actions', () => {
+
+  describe('`editEventRequest` action creator', () => {
+
+    it('returns expected action', () => {
+
+      const expected = {
+        type: actions.EDIT_EVENT_REQUEST
+      };
+
+      const actual = actions.editEventRequest();
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('`editEventSuccess` action creator', () => {
+
+    it('returns expected action', () => {
+      const data = {};
+      const expected = {
+        type: actions.EDIT_EVENT_SUCCESS,
+        data
+      };
+
+      const actual = actions.editEventSuccess(data);
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('`editEventFailure` action creator', () => {
+
+    it('returns expected action', () => {
+
+      const error = new Error();
+      const expected = {
+        type: actions.EDIT_EVENT_FAILURE,
+        error
+      };
+
+      const actual = actions.editEventFailure(error);
+      expect(actual).toEqual(expected);
+    });
+  });
+});
+
+
+describe('UPDATE_RSVP actions', () => {
+
+  describe('`updateRsvpRequest` action creator', () => {
+
+    it('returns expected action', () => {
+
+      const expected = {
+        type: actions.UPDATE_RSVP_REQUEST
+      };
+
+      const actual = actions.updateRsvpRequest();
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('`updateRsvpSuccess` action creator', () => {
+
+    it('returns expected action', () => {
+      const data = { going: [{ firstname: 'Mickey', surname: 'Mouse' }] };
+      const expected = {
+        type: actions.UPDATE_RSVP_SUCCESS,
+        data
+      };
+
+      const actual = actions.updateRsvpSuccess(data);
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('`updateRsvpFailure` action creator', () => {
+
+    it('returns expected action', () => {
+
+      const error = new Error();
+      const expected = {
+        type: actions.UPDATE_RSVP_FAILURE,
+        error
+      };
+
+      const actual = actions.updateRsvpFailure(error);
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest --runInBand --forceExit --coverage",
+    "test-watch": "jest --runInBand --forceExit --coverage --watch",
     "lint": "node_modules/eslint/bin/eslint.js 'src/**/*.js' '__tests__/**/*.js'",
     "precommit": "npm run lint",
     "prepush": "npm test",

--- a/src/js/actions/event/data.js
+++ b/src/js/actions/event/data.js
@@ -9,6 +9,9 @@ export const SUBMIT_CODE_FAILURE = 'SUBMIT_CODE_FAILURE';
 export const EDIT_EVENT_REQUEST = 'EDIT_EVENT_REQUEST';
 export const EDIT_EVENT_SUCCESS = 'EDIT_EVENT_SUCCESS';
 export const EDIT_EVENT_FAILURE = 'EDIT_EVENT_FAILURE';
+export const UPDATE_RSVP_REQUEST = 'UPDATE_RSVP_REQUEST';
+export const UPDATE_RSVP_SUCCESS = 'UPDATE_RSVP_SUCCESS';
+export const UPDATE_RSVP_FAILURE = 'UPDATE_RSVP_FAILURE';
 
 export const getEventRequest = () => ({
   type: GET_EVENT_REQUEST
@@ -24,6 +27,21 @@ export const getEventFailure = error => ({
   error
 });
 
+export const submitCodeRequest = () => ({
+  type: SUBMIT_CODE_REQUEST
+});
+
+export const submitCodeSuccess = data => ({
+  type: SUBMIT_CODE_SUCCESS,
+  data
+});
+
+export const submitCodeFailure = error => ({
+  type: SUBMIT_CODE_FAILURE,
+  error
+});
+
+
 export const editEventRequest = () => ({
   type: EDIT_EVENT_REQUEST
 });
@@ -38,10 +56,23 @@ export const editEventFailure = error => ({
   error
 });
 
+export const updateRsvpRequest = () => ({
+  type: UPDATE_RSVP_REQUEST
+});
+
+export const updateRsvpSuccess = data => ({
+  type: UPDATE_RSVP_SUCCESS,
+  data
+});
+
+export const updateRsvpFailure = error => ({
+  type: UPDATE_RSVP_FAILURE,
+  error
+});
+
 export function getEvent (token, event_id) {
   return (dispatch) => {
     dispatch(getEventRequest());
-    console.log('event_id to server', event_id);
     fetch(`http://localhost:3000/events/${event_id}`, {
       method: 'GET',
       headers: {
@@ -53,7 +84,6 @@ export function getEvent (token, event_id) {
     .then((res) => {
       res.json()
       .then((data) => {
-        console.log('FROM SERVER', data);
         dispatch(getEventSuccess(data));
         pushTo('event');
       })
@@ -87,21 +117,8 @@ export function editEvent (token, event, event_id) {
   };
 }
 
-export const submitCodeRequest = () => ({
-  type: SUBMIT_CODE_REQUEST
-});
 
-export const submitCodeSuccess = data => ({
-  type: SUBMIT_CODE_SUCCESS,
-  data
-});
-
-export const submitCodeFailure = error => ({
-  type: SUBMIT_CODE_FAILURE,
-  error
-});
-
-export function submitCode (token, code) { //eslint-disable-line
+export function submitCode (token, code) {
   return (dispatch) => {
     dispatch(submitCodeRequest());
     fetch('http://localhost:3000/events/rsvps', {
@@ -127,5 +144,33 @@ export function submitCode (token, code) { //eslint-disable-line
       .catch(err => dispatch(submitCodeFailure(err)));
     })
     .catch(err => dispatch(submitCodeFailure(err)));
+  };
+}
+
+export function updateRsvp (token, event_id, status) {
+  return (dispatch) => {
+    dispatch(updateRsvpRequest());
+    fetch(`http://localhost:3000/events/${event_id}/rsvps`, {
+      method: 'PATCH',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        authorization: token
+      },
+      body: JSON.stringify({ status })
+    })
+    .then((res) => {
+      res.json()
+      .then((data) => {
+        if (data.error) {
+          dispatch(updateRsvpFailure(data.error));
+        } else {
+          console.log(data);
+          dispatch(updateRsvpSuccess(data));
+        }
+      })
+      .catch(err => dispatch(updateRsvpFailure(err)));
+    })
+    .catch(err => dispatch(updateRsvpFailure(err)));
   };
 }

--- a/src/js/components/create/confirm-when.js
+++ b/src/js/components/create/confirm-when.js
@@ -22,7 +22,7 @@ const ConfirmWhen = ({ data }) => {
         }
         { (!hideTitle) &&
           <View style={{ flexBasis: 60, marginHorizontal: 5 }}>
-            <Text style={styles.optionTitleWhat}>
+            <Text style={styles.optionTitleWhen}>
               When
             </Text>
           </View>

--- a/src/js/components/event/finalised-event.js
+++ b/src/js/components/event/finalised-event.js
@@ -45,14 +45,9 @@ const inlineStyle = {
 const FinalisedEvent = ({ event, event_id, userIsHost, rsvpToEvent, rsvps }) => {
   const handleClick = !userIsHost ? rsvpToEvent : '';
 
-  const going = rsvps.going;
-  const notGoing = rsvps.not_going;
-  const maybe = rsvps.maybe;
-  const respondedList = going.concat(maybe, notGoing);
-  const placeNameLong = (event.where[0] && event.where[0].placeName > 18);
-
   return (
     <View style={{ flex: 1 }}>
+      { userIsHost ? <Text>Host view</Text> : <Text>Invitee view</Text> }
       <ScrollView>
 
         <View style={{ flexDirection: 'row' }}>
@@ -81,9 +76,9 @@ const FinalisedEvent = ({ event, event_id, userIsHost, rsvpToEvent, rsvps }) => 
                 <Text>Going</Text>
               </Button>
               {
-                going && going.map((user) => {
+                rsvps.going && rsvps.going.map((invitee) => {
                   return (
-                    <InviteeCard firstname={user.firstname} photo_url={user.photo_url} />
+                    <InviteeCard firstname={invitee.firstname} photo_url={invitee.photo_url} />
                   );
                 })
               }
@@ -97,9 +92,9 @@ const FinalisedEvent = ({ event, event_id, userIsHost, rsvpToEvent, rsvps }) => 
                 <Text>Maybe</Text>
               </Button>
               {
-                maybe && maybe.map((user) => {
+                rsvps.maybe && rsvps.maybe.map((invitee) => {
                   return (
-                    <InviteeCard firstname={user.firstname} photo_url={user.photo_url} />
+                    <InviteeCard firstname={invitee.firstname} photo_url={invitee.photo_url} />
                   );
                 })
               }
@@ -113,13 +108,26 @@ const FinalisedEvent = ({ event, event_id, userIsHost, rsvpToEvent, rsvps }) => 
                 <Text>Not Going</Text>
               </Button>
               {
-                notGoing && notGoing.map((user) => {
+                rsvps.not_going && rsvps.not_going.map((invitee) => {
                   return (
-                    <InviteeCard firstname={user.firstname} photo_url={user.photo_url} />
+                    <InviteeCard firstname={invitee.firstname} photo_url={invitee.photo_url} />
                   );
                 })
               }
             </View>
+          </View>
+          <Text>Not responded</Text>
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
+            {
+              rsvps.not_responded.map((invitee) => {
+                return (
+                  <InviteeCard
+                    firstname={ invitee.firstname }
+                    photo_url={ invitee.photo_url }
+                  />
+                );
+              })
+            }
           </View>
         </View>
 

--- a/src/js/components/event/finalised-event.js
+++ b/src/js/components/event/finalised-event.js
@@ -47,7 +47,6 @@ const inlineStyle = {
 };
 
 const FinalisedEvent = ({ event, userIsHost, rsvpToEvent, rsvps }) => {
-  const handleClick = !userIsHost ? rsvpToEvent : '';
   return (
     <View style={{ flex: 1 }}>
       { userIsHost ? <Text>Host view</Text> : <Text>Invitee view</Text> }

--- a/src/js/components/event/finalised-event.js
+++ b/src/js/components/event/finalised-event.js
@@ -134,7 +134,6 @@ const FinalisedEvent = ({ event, event_id, userIsHost, rsvpToEvent, rsvps }) => 
       </ScrollView>
     </View>
   );
-
 };
 
 export default FinalisedEvent;

--- a/src/js/components/event/finalised-event.js
+++ b/src/js/components/event/finalised-event.js
@@ -14,6 +14,10 @@ import InviteeCard from './invitee-card';
 import styles from '../../../styles';
 import colours from '../../../styles/colours';
 
+const STATUS_GOING = 'going';
+const STATUS_MAYBE = 'maybe';
+const STATUS_NOT_GOING = 'not_going';
+
 const inlineStyle = {
   button: {
     flexBasis: 100,
@@ -42,9 +46,8 @@ const inlineStyle = {
   }
 };
 
-const FinalisedEvent = ({ event, event_id, userIsHost, rsvpToEvent, rsvps }) => {
+const FinalisedEvent = ({ event, userIsHost, rsvpToEvent, rsvps }) => {
   const handleClick = !userIsHost ? rsvpToEvent : '';
-
   return (
     <View style={{ flex: 1 }}>
       { userIsHost ? <Text>Host view</Text> : <Text>Invitee view</Text> }
@@ -71,7 +74,7 @@ const FinalisedEvent = ({ event, event_id, userIsHost, rsvpToEvent, rsvps }) => 
               <Button
                 buttonStyle={[styles.confirmButton, inlineStyle.button, inlineStyle.greenButton]}
                 textStyle={styles.confirmButtonText}
-                onPress={ () => handleClick('going', event_id) }
+                onPress={ () => !userIsHost && rsvpToEvent(event.event_id, STATUS_GOING) }
               >
                 <Text>Going</Text>
               </Button>
@@ -87,7 +90,7 @@ const FinalisedEvent = ({ event, event_id, userIsHost, rsvpToEvent, rsvps }) => 
               <Button
                 buttonStyle={[styles.confirmButton, inlineStyle.button, inlineStyle.orangeButton]}
                 textStyle={styles.confirmButtonText}
-                onPress={ () => handleClick('maybe', event_id) }
+                onPress={ () => !userIsHost && rsvpToEvent(event.event_id, STATUS_MAYBE) }
               >
                 <Text>Maybe</Text>
               </Button>
@@ -103,7 +106,7 @@ const FinalisedEvent = ({ event, event_id, userIsHost, rsvpToEvent, rsvps }) => 
               <Button
                 buttonStyle={[styles.confirmButton, inlineStyle.button, inlineStyle.redButton]}
                 textStyle={styles.confirmButtonText}
-                onPress={ () => handleClick('notGoing', event_id) }
+                onPress={ () => !userIsHost && rsvpToEvent(event.event_id, STATUS_NOT_GOING) }
               >
                 <Text>Not Going</Text>
               </Button>

--- a/src/js/components/event/index.js
+++ b/src/js/components/event/index.js
@@ -3,7 +3,6 @@ import { View, Text } from 'react-native';
 import InviteePoll from './invitee-poll';
 import HostPoll from './host-poll';
 import FinalisedEvent from './finalised-event';
-import Spinner from '../common/Spinner';
 import DeletedEvent from './deleted-event';
 import colours from '../../../styles/colours';
 import Button from '../common/Button';
@@ -96,13 +95,10 @@ export default class Event extends React.Component {
     return (
       <View style={{ flex: 1 }}>
         {
-          this.props.isFetching && <Spinner />
-        }
-        {
           !this.props.isFetching && (this.props.event === false) && <DeletedEvent />
         }
         {
-          !this.props.isFetching && this.props.event && this.eventRouter()
+          this.props.event && this.eventRouter()
         }
       </View>
     );

--- a/src/js/components/event/invitee-card.js
+++ b/src/js/components/event/invitee-card.js
@@ -1,5 +1,7 @@
 import React, { PropTypes } from 'react';
-import { Text, View, Image } from 'react-native';
+import { Text, View, Image, Dimensions } from 'react-native';
+
+const windowWidth = Dimensions.get('window').width;
 
 const cardStyle = {
   height: 30,
@@ -13,7 +15,7 @@ const cardStyle = {
   flexDirection: 'row',
   justifyContent: 'space-between',
   flex: 1,
-  maxWidth: 120
+  maxWidth: windowWidth * 0.33
 };
 const imageStyle = {
   width: 30,
@@ -29,7 +31,7 @@ export default function InviteeCard ({ firstname, photo_url }) {
   return (
     <View style={cardStyle}>
       <Image source={{ uri: photo_url }} style={imageStyle} />
-      <Text style={textStyle}>{firstname}</Text>
+      <Text numberOfLines={1} style={textStyle}>{firstname}</Text>
     </View>
   );
 }

--- a/src/js/components/event/invitee-card.js
+++ b/src/js/components/event/invitee-card.js
@@ -11,7 +11,9 @@ const cardStyle = {
   backgroundColor: '#efefef',
   alignItems: 'center',
   flexDirection: 'row',
-  justifyContent: 'space-between'
+  justifyContent: 'space-between',
+  flex: 1,
+  maxWidth: 120
 };
 const imageStyle = {
   width: 30,
@@ -24,7 +26,6 @@ const textStyle = {
 };
 
 export default function InviteeCard ({ firstname, photo_url }) {
-  console.log(photo_url);
   return (
     <View style={cardStyle}>
       <Image source={{ uri: photo_url }} style={imageStyle} />

--- a/src/js/components/navbar.js
+++ b/src/js/components/navbar.js
@@ -26,19 +26,6 @@ export default function Navbar () {
       </TabItem>
 
       <TabItem
-        id="albums"
-        title="Albums"
-        selectedStyle={ tabBarSelectedItemStyle }
-        renderIcon={ isSelected => <Icon name="camera" size={ 28 } color={ isSelected ? colours.blue : colours.gray } /> }
-      >
-        <StackNavigation
-          id="albums"
-          navigatorUID="albums"
-          initialRoute={ Router.getRoute('albums', { title: 'Albums' }) }
-        />
-      </TabItem>
-
-      <TabItem
         id="calendar"
         title="Calendar"
         selectedStyle={ tabBarSelectedItemStyle }

--- a/src/js/containers/event.js
+++ b/src/js/containers/event.js
@@ -5,7 +5,7 @@ import { NavigationActions } from '@exponent/ex-navigation';
 import { store } from '../init-store';
 import Router from '../router';
 import Event from '../components/event';
-import { getEvent } from '../actions/event/data';
+import { getEvent, updateRsvp } from '../actions/event/data';
 import { postVote, finaliseEvent } from '../actions/event/poll';
 import { hydrateCreateEvent, clearCreateEvent } from '../actions/create';
 import normaliseVoteData from '../lib/normalise-vote-data';
@@ -59,9 +59,13 @@ const mapDispatchToProps = dispatch => ({
     dispatch(NavigationActions.push(navigatorUID, Router.getRoute('edit')));
     // get event?
   },
-  rsvpToEvent: (status, event_id) => {
-
-    // update rsvp
+  rsvpToEvent: (event_id, status) => {
+    AsyncStorage.getItem('spark_token')
+    .then((token) => {
+      if (token) {
+        dispatch(updateRsvp(token, event_id, status));
+      }
+    });
   },
   discardEvent: () => {
     dispatch(clearCreateEvent());

--- a/src/js/reducers/event/data.js
+++ b/src/js/reducers/event/data.js
@@ -1,4 +1,3 @@
-import update from 'immutability-helper';
 import * as actions from '../../actions/event/data';
 
 export const initialState = {
@@ -13,8 +12,12 @@ export const initialState = {
   what: [],
   where: [],
   when: [],
-  rsvps: [],
-  eventEdited: false,
+  rsvps: {
+    going: [],
+    maybe: [],
+    not_going: [],
+    not_responded: []
+  },
   isFetching: false
 };
 
@@ -25,9 +28,7 @@ export default function data (state = initialState, action) {
     case actions.GET_EVENT_REQUEST:
     case actions.EDIT_EVENT_REQUEST:
     case actions.SUBMIT_CODE_REQUEST:
-      return update(state, {
-        isFetching: { $set: true }
-      });
+      return { ...state, isFetching: true };
 
     case actions.GET_EVENT_SUCCESS:
     case actions.EDIT_EVENT_SUCCESS:
@@ -37,10 +38,7 @@ export default function data (state = initialState, action) {
     case actions.GET_EVENT_FAILURE:
     case actions.EDIT_EVENT_FAILURE:
     case actions.SUBMIT_CODE_FAILURE:
-      return update(state, {
-        isFetching: { $set: false },
-        error: { $set: action.error }
-      });
+      return { ...state, ...action.error, isFetching: false };
 
     default:
       return state;

--- a/src/js/reducers/event/data.js
+++ b/src/js/reducers/event/data.js
@@ -28,16 +28,19 @@ export default function data (state = initialState, action) {
     case actions.GET_EVENT_REQUEST:
     case actions.EDIT_EVENT_REQUEST:
     case actions.SUBMIT_CODE_REQUEST:
+    case actions.UPDATE_RSVP_REQUEST:
       return { ...state, isFetching: true };
 
     case actions.GET_EVENT_SUCCESS:
     case actions.EDIT_EVENT_SUCCESS:
     case actions.SUBMIT_CODE_SUCCESS:
+    case actions.UPDATE_RSVP_SUCCESS:
       return { ...state, ...action.data, isFetching: false };
 
     case actions.GET_EVENT_FAILURE:
     case actions.EDIT_EVENT_FAILURE:
     case actions.SUBMIT_CODE_FAILURE:
+    case actions.UPDATE_RSVP_FAILURE:
       return { ...state, ...action.error, isFetching: false };
 
     default:


### PR DESCRIPTION
Closes #149, closed #142 
- invitees can rsvp by clicking on the `going`, `maybe` and `not going` buttons
- invitees who haven't responded are displayed in the `not responded` section
- improves styling slightly on FinalisedEvent view
- removes spinner from FinalisedEvent view (looks smoother without it when user updates their rsvp)
- removes Albums button from TabBar to avoid this:
<img width="353" alt="screen shot 2017-02-16 at 17 18 13" src="https://cloud.githubusercontent.com/assets/8915092/23047469/ded22e78-f4a7-11e6-93d7-cce7139dca4e.png">
