### PR TITLE
feat: displays submitCodeFailure error message. refactor: passes erro…

### DIFF
--- a/src/js/actions/event/data.js
+++ b/src/js/actions/event/data.js
@@ -109,9 +109,9 @@ export function getEvent (token, event_id) {
         dispatch(getEventSuccess(data));
         pushTo('event');
       })
-      .catch(err => dispatch(getEventFailure(err)));
+      .catch(err => dispatch(getEventFailure(err.message)));
     })
-    .catch(err => dispatch(getEventFailure(err)));
+    .catch(err => dispatch(getEventFailure(err.message)));
   };
 }
 
@@ -133,9 +133,9 @@ export function editEvent (token, event, event_id) {
       .then((data) => {
         dispatch(editEventSuccess(data));
       })
-      .catch(err => dispatch(editEventFailure(err)));
+      .catch(err => dispatch(editEventFailure(err.message)));
     })
-    .catch(err => dispatch(editEventFailure(err)));
+    .catch(err => dispatch(editEventFailure(err.message)));
   };
 }
 
@@ -163,9 +163,9 @@ export function submitCode (token, code) {
           resetStackTo('event');
         }
       })
-      .catch(err => dispatch(submitCodeFailure(err)));
+      .catch(err => dispatch(submitCodeFailure(err.message)));
     })
-    .catch(err => dispatch(submitCodeFailure(err)));
+    .catch(err => dispatch(submitCodeFailure(err.message)));
   };
 }
 
@@ -190,9 +190,9 @@ export function updateRsvp (token, event_id, status) {
           dispatch(updateRsvpSuccess(data));
         }
       })
-      .catch(err => dispatch(updateRsvpFailure(err)));
+      .catch(err => dispatch(updateRsvpFailure(err.message)));
     })
-    .catch(err => dispatch(updateRsvpFailure(err)));
+    .catch(err => dispatch(updateRsvpFailure(err.message)));
   };
 }
 
@@ -213,8 +213,8 @@ export function deleteEvent (token, event_id) {
         dispatch(deleteEventSuccess());
         resetStackTo('feed');
       })
-      .catch(err => dispatch(deleteEventFailure(err)));
+      .catch(err => dispatch(deleteEventFailure(err.message)));
     })
-    .catch(err => dispatch(deleteEventFailure(err)));
+    .catch(err => dispatch(deleteEventFailure(err.message)));
   };
 }

--- a/src/js/components/code.js
+++ b/src/js/components/code.js
@@ -37,7 +37,7 @@ class Code extends Component {
   }
 
   render () {
-    const { handleSubmit, handleSubmitForm } = this.props;
+    const { handleSubmit, handleSubmitForm, codeError } = this.props;
     return (
       <View style={{ flex: 1 }}>
         <View style={{ alignItems: 'center', marginTop: 50, marginBottom: 70 }}>
@@ -57,6 +57,10 @@ class Code extends Component {
               <Text>JOIN EVENT</Text>
             </Button>
           </View>
+          {
+            codeError &&
+            <Text style={{ color: 'red' }}>{ codeError }</Text>
+          }
         </View>
       </View>
     );

--- a/src/js/containers/code.js
+++ b/src/js/containers/code.js
@@ -3,6 +3,12 @@ import { connect } from 'react-redux';
 import Code from '../components/code';
 import { submitCode } from '../actions/event/data';
 
+const mapStateToProps = ({ event }) => {
+  return {
+    codeError: event.data.error
+  };
+};
+
 const mapDispatchToProps = () => ({
   handleSubmitForm: ({ code }, dispatch, props) => { //eslint-disable-line
     AsyncStorage.getItem('spark_token')
@@ -16,4 +22,4 @@ const mapDispatchToProps = () => ({
   }
 });
 
-export default connect(mapDispatchToProps)(Code);
+export default connect(mapStateToProps, mapDispatchToProps)(Code);

--- a/src/js/reducers/event/data.js
+++ b/src/js/reducers/event/data.js
@@ -17,7 +17,8 @@ export const initialState = {
     not_going: [],
     not_responded: []
   },
-  isFetching: false
+  isFetching: false,
+  error: undefined
 };
 
 export default function data (state = initialState, action) {
@@ -45,7 +46,7 @@ export default function data (state = initialState, action) {
     case actions.SUBMIT_CODE_FAILURE:
     case actions.UPDATE_RSVP_FAILURE:
     case actions.DELETE_EVENT_FAILURE:
-      return { ...state, ...action.error, isFetching: false };
+      return { ...state, error: action.error, isFetching: false };
 
     default:
       return state;


### PR DESCRIPTION
…r string to event/data reducer #156 

@heron2014 I think ex-navigation passes down a prop called `error`, so if we want to pass errors down to components we need to name them something different (otherwise it's undefined)