### PR TITLE
Navigation fix

### DIFF
--- a/src/js/components/navbar.js
+++ b/src/js/components/navbar.js
@@ -4,20 +4,13 @@ import Icon from 'react-native-vector-icons/FontAwesome';
 import Router from '../router';
 import { tabBarSelectedItemStyle } from '../../styles';
 import colours from '../../styles/colours';
-// import { popToTop } from '../lib/navigate';
-
+import { popToTop } from '../lib/navigate';
 
 export default class Navbar extends Component {
 
-  onPress = (tabItemOnPress, event) => { //eslint-disable-line
+  onPress = (tabItemOnPress) => {
     tabItemOnPress();
-    this.props.navigation.performAction(({ tabs, stacks }) => { // eslint-disable-line no-unused-vars
-      console.log('tabs', tabs, 'stacks', stacks);
-      const { currentNavigatorUID } = this.props.navigation.navigationState;
-      if (this.props.navigation.navigationState.currentNavigatorUID !== 'main') {
-        stacks(currentNavigatorUID).popToTop(currentNavigatorUID);
-      }
-    });
+    popToTop(this.props.navigation);
   }
 
   render () {
@@ -26,14 +19,13 @@ export default class Navbar extends Component {
         id="main"
         navigatorUID="main"
         initialTab="feed"
-
       >
         <TabItem
           id="code"
           title="Code"
           selectedStyle={ tabBarSelectedItemStyle }
           renderIcon={ isSelected => <Icon name="barcode" size={ 28 } color={ isSelected ? colours.blue : colours.gray } /> }
-          onPress={this.onPress }
+          onPress={ this.onPress }
         >
           <StackNavigation
             id="code"
@@ -45,9 +37,10 @@ export default class Navbar extends Component {
         <TabItem
           id="calendar"
           title="Calendar"
+          navigatorUID="calendar"
           selectedStyle={ tabBarSelectedItemStyle }
           renderIcon={ isSelected => <Icon name="calendar" size={ 28 } color={ isSelected ? colours.blue : colours.gray} /> }
-          onPress={this.onPress }
+          onPress={ this.onPress }
         >
           <StackNavigation
             id="calendar"
@@ -61,7 +54,7 @@ export default class Navbar extends Component {
           title="Feed"
           selectedStyle={ tabBarSelectedItemStyle }
           renderIcon={ isSelected => <Icon name="globe" size={ 28 } color={ isSelected ? colours.blue : colours.gray } /> }
-          onPress={this.onPress }
+          onPress={ this.onPress }
         >
           <StackNavigation
             id="feed"
@@ -75,7 +68,7 @@ export default class Navbar extends Component {
           title="Profile"
           selectedStyle={ tabBarSelectedItemStyle }
           renderIcon={ isSelected => <Icon name="user" size={ 28 } color={ isSelected ? colours.blue : colours.gray} /> }
-          onPress={this.onPress }
+          onPress={ this.onPress }
         >
           <StackNavigation
             id="profile"
@@ -89,7 +82,7 @@ export default class Navbar extends Component {
           title="Create"
           selectedStyle={ tabBarSelectedItemStyle }
           renderIcon={ isSelected => <Icon name="pencil" size={ 28 } color={ isSelected ? colours.blue : colours.gray } /> }
-          onPress={this.onPress }
+          onPress={ this.onPress }
         >
           <StackNavigation
             id="create"

--- a/src/js/components/navbar.js
+++ b/src/js/components/navbar.js
@@ -1,81 +1,103 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { StackNavigation, TabNavigation, TabNavigationItem as TabItem } from '@exponent/ex-navigation';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import Router from '../router';
 import { tabBarSelectedItemStyle } from '../../styles';
 import colours from '../../styles/colours';
+// import { popToTop } from '../lib/navigate';
 
-export default function Navbar () {
-  return (
-    <TabNavigation
-      id="main"
-      navigatorUID="main"
-      initialTab="feed"
-    >
-      <TabItem
-        id="code"
-        title="Code"
-        selectedStyle={ tabBarSelectedItemStyle }
-        renderIcon={ isSelected => <Icon name="barcode" size={ 28 } color={ isSelected ? colours.blue : colours.gray } /> }
+
+export default class Navbar extends Component {
+
+  onPress = (tabItemOnPress, event) => { //eslint-disable-line
+    tabItemOnPress();
+    this.props.navigation.performAction(({ tabs, stacks }) => { // eslint-disable-line no-unused-vars
+      console.log('tabs', tabs, 'stacks', stacks);
+      const { currentNavigatorUID } = this.props.navigation.navigationState;
+      if (this.props.navigation.navigationState.currentNavigatorUID !== 'main') {
+        stacks(currentNavigatorUID).popToTop(currentNavigatorUID);
+      }
+    });
+  }
+
+  render () {
+    return (
+      <TabNavigation
+        id="main"
+        navigatorUID="main"
+        initialTab="feed"
+
       >
-        <StackNavigation
+        <TabItem
           id="code"
-          navigatorUID="code"
-          initialRoute={ Router.getRoute('code', { title: 'Code' }) }
-        />
-      </TabItem>
+          title="Code"
+          selectedStyle={ tabBarSelectedItemStyle }
+          renderIcon={ isSelected => <Icon name="barcode" size={ 28 } color={ isSelected ? colours.blue : colours.gray } /> }
+          onPress={this.onPress }
+        >
+          <StackNavigation
+            id="code"
+            navigatorUID="code"
+            initialRoute={ Router.getRoute('code', { title: 'Code' }) }
+          />
+        </TabItem>
 
-      <TabItem
-        id="calendar"
-        title="Calendar"
-        selectedStyle={ tabBarSelectedItemStyle }
-        renderIcon={ isSelected => <Icon name="calendar" size={ 28 } color={ isSelected ? colours.blue : colours.gray} /> }
-      >
-        <StackNavigation
+        <TabItem
           id="calendar"
-          navigatorUID="calendar"
-          initialRoute={ Router.getRoute('calendar', { title: 'Calendar' }) }
-        />
-      </TabItem>
+          title="Calendar"
+          selectedStyle={ tabBarSelectedItemStyle }
+          renderIcon={ isSelected => <Icon name="calendar" size={ 28 } color={ isSelected ? colours.blue : colours.gray} /> }
+          onPress={this.onPress }
+        >
+          <StackNavigation
+            id="calendar"
+            navigatorUID="calendar"
+            initialRoute={ Router.getRoute('calendar', { title: 'Calendar' }) }
+          />
+        </TabItem>
 
-      <TabItem
-        id="feed"
-        title="Feed"
-        selectedStyle={ tabBarSelectedItemStyle }
-        renderIcon={ isSelected => <Icon name="globe" size={ 28 } color={ isSelected ? colours.blue : colours.gray } /> }
-      >
-        <StackNavigation
+        <TabItem
           id="feed"
-          navigatorUID="feed"
-          initialRoute={ Router.getRoute('feed') }
-        />
-      </TabItem>
+          title="Feed"
+          selectedStyle={ tabBarSelectedItemStyle }
+          renderIcon={ isSelected => <Icon name="globe" size={ 28 } color={ isSelected ? colours.blue : colours.gray } /> }
+          onPress={this.onPress }
+        >
+          <StackNavigation
+            id="feed"
+            navigatorUID="feed"
+            initialRoute={ Router.getRoute('feed') }
+          />
+        </TabItem>
 
-      <TabItem
-        id="profile"
-        title="Profile"
-        selectedStyle={ tabBarSelectedItemStyle }
-        renderIcon={ isSelected => <Icon name="user" size={ 28 } color={ isSelected ? colours.blue : colours.gray} /> }
-      >
-        <StackNavigation
+        <TabItem
           id="profile"
-          navigatorUID="profile"
-          initialRoute={ Router.getRoute('profile') }
-        />
-      </TabItem>
+          title="Profile"
+          selectedStyle={ tabBarSelectedItemStyle }
+          renderIcon={ isSelected => <Icon name="user" size={ 28 } color={ isSelected ? colours.blue : colours.gray} /> }
+          onPress={this.onPress }
+        >
+          <StackNavigation
+            id="profile"
+            navigatorUID="profile"
+            initialRoute={ Router.getRoute('profile') }
+          />
+        </TabItem>
 
-      <TabItem
-        id="create"
-        title="Create"
-        selectedStyle={ tabBarSelectedItemStyle }
-        renderIcon={ isSelected => <Icon name="pencil" size={ 28 } color={ isSelected ? colours.blue : colours.gray } /> }
-      >
-        <StackNavigation
+        <TabItem
           id="create"
-          navigatorUID="create"
-          initialRoute={ Router.getRoute('details') }
-        />
-      </TabItem>
-    </TabNavigation>
-  );
+          title="Create"
+          selectedStyle={ tabBarSelectedItemStyle }
+          renderIcon={ isSelected => <Icon name="pencil" size={ 28 } color={ isSelected ? colours.blue : colours.gray } /> }
+          onPress={this.onPress }
+        >
+          <StackNavigation
+            id="create"
+            navigatorUID="create"
+            initialRoute={ Router.getRoute('details') }
+          />
+        </TabItem>
+      </TabNavigation>
+    );
+  }
 }


### PR DESCRIPTION
This PR enables to redirect to initial screen Tab by clicking twice on Tab. **This is the same behaviour as Instagram has.** So for example: 

User clicks on Feed Tab , then from Feed tab clicks on event, user is redirected to the Event screen.
User clicks now on Profile Tab and then clicks back on Feed tab - user will see the last screen which is that particular event - to go back to initial view - user have two options: 
- either clicks on the back arrows from the top navbar
- or clicks on Feed tab again


Relates to #251 